### PR TITLE
Adjust policy temperature based on Q

### DIFF
--- a/Logic/MCTS/SearchUtils.cs
+++ b/Logic/MCTS/SearchUtils.cs
@@ -30,9 +30,10 @@ public static unsafe class SearchUtils
         return float.Exp(0.5f * float.Log10(Math.Max(node.Visits, 1)));
     }
 
-    public static float GetPST(uint depth, float q)
+    public static float GetTemperatureAdjustment(uint depth, float q)
     {
-        return 1.0f;
+        var value = (q - Math.Min(q, TemperatureQInc)) / (1.0f - TemperatureQInc);
+        return 1.0f + value * TemperatureScale;
     }
 
     public static float PolicyForMove(Position pos, Move move)

--- a/Logic/MCTS/Tree.cs
+++ b/Logic/MCTS/Tree.cs
@@ -126,7 +126,7 @@ public unsafe class Tree
         if (!ReserveNodes(count, out uint newPtr))
             return false;
 
-        var pst = SearchUtils.GetPST(depth, this[nodeIndex].QValue);
+        var pst = SearchUtils.GetTemperatureAdjustment(depth, this[nodeIndex].QValue);
 
         float total = 0.0f;
         for (uint i = 0; i < count; i++)

--- a/Logic/Search/SearchOptions.cs
+++ b/Logic/Search/SearchOptions.cs
@@ -17,5 +17,8 @@
         public static int SEEValueBishop = 315;
         public static int SEEValueRook = 535;
         public static int SEEValueQueen = 970;
+
+        public static float TemperatureQInc = 0.75f;
+        public static float TemperatureScale = 0.25f;
     }
 }


### PR DESCRIPTION
```
Elo   | 3.18 +- 2.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 34690 W: 9320 L: 9002 D: 16368
Penta | [1075, 4108, 6733, 4282, 1147]
```
https://somelizard.pythonanywhere.com/test/2622/