### PR TITLE
Increase cpuct visit scaling coefficient

### DIFF
--- a/Logic/MCTS/SearchUtils.cs
+++ b/Logic/MCTS/SearchUtils.cs
@@ -14,7 +14,7 @@ public static unsafe class SearchUtils
     {
         var cpu = isRootNode ? 0.5f : 0.25f;
         
-        var scale = 5000.0f;
+        var scale = 4000.0f;
         cpu *= 1 + float.Log10((node.Visits + scale) / scale);
 
         return cpu;


### PR DESCRIPTION
```
Elo   | 21.89 +- 9.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2352 W: 676 L: 528 D: 1148
Penta | [46, 245, 484, 317, 84]
```
https://somelizard.pythonanywhere.com/test/2625/