### PR TITLE
Slightly adjust temperature by depth

### DIFF
--- a/Logic/MCTS/SearchUtils.cs
+++ b/Logic/MCTS/SearchUtils.cs
@@ -30,10 +30,13 @@ public static unsafe class SearchUtils
         return float.Exp(0.5f * float.Log10(Math.Max(node.Visits, 1)));
     }
 
-    public static float GetTemperatureAdjustment(uint depth, float q)
+    public static float GetTemperatureAdjustment(int depth, float q)
     {
         var value = (q - Math.Min(q, TemperatureQInc)) / (1.0f - TemperatureQInc);
-        var dCoef = MathF.Sin(depth * MathF.PI / 2) / 10;
+
+        //  sin(x * pi / 2) / 8
+        var dCoef = ((2 - (depth % 4)) * (depth % 2)) / 8.0f;
+
         return 1.0f + value * TemperatureScale + dCoef;
     }
 

--- a/Logic/MCTS/SearchUtils.cs
+++ b/Logic/MCTS/SearchUtils.cs
@@ -33,7 +33,8 @@ public static unsafe class SearchUtils
     public static float GetTemperatureAdjustment(uint depth, float q)
     {
         var value = (q - Math.Min(q, TemperatureQInc)) / (1.0f - TemperatureQInc);
-        return 1.0f + value * TemperatureScale;
+        var dCoef = MathF.Sin(depth * MathF.PI / 2) / 10;
+        return 1.0f + value * TemperatureScale + dCoef;
     }
 
     public static float PolicyForMove(Position pos, Move move)

--- a/Logic/MCTS/Tree.cs
+++ b/Logic/MCTS/Tree.cs
@@ -126,7 +126,7 @@ public unsafe class Tree
         if (!ReserveNodes(count, out uint newPtr))
             return false;
 
-        var pst = SearchUtils.GetTemperatureAdjustment(depth, this[nodeIndex].QValue);
+        var pst = SearchUtils.GetTemperatureAdjustment((int)depth, this[nodeIndex].QValue);
 
         float total = 0.0f;
         for (uint i = 0; i < count; i++)


### PR DESCRIPTION
This test used a divisor of 10.
```
Elo   | 8.19 +- 5.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7850 W: 2136 L: 1951 D: 3763
Penta | [266, 856, 1488, 1057, 258]
```
https://somelizard.pythonanywhere.com/test/2627/