### PR TITLE
Fix exploration scaling logarithm base

### DIFF
--- a/Logic/MCTS/SearchUtils.cs
+++ b/Logic/MCTS/SearchUtils.cs
@@ -27,7 +27,7 @@ public static unsafe class SearchUtils
 
     public static float GetExplorationScale(in Node node)
     {
-        return float.Exp(0.5f * float.Log10(Math.Max(node.Visits, 1)));
+        return float.Exp(0.5f * float.Log(Math.Max(node.Visits, 1)));
     }
 
     public static float GetTemperatureAdjustment(int depth, float q)


### PR DESCRIPTION
```
Elo   | 728.11 +- 217.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.25, 2.89) [0.00, 5.00]
Games | N: 302 W: 293 L: 0 D: 9
Penta | [0, 0, 1, 7, 143]
```
https://somelizard.pythonanywhere.com/test/2630/