### PR TITLE
Higher root PST, decaying at higher depths

### DIFF
--- a/Logic/MCTS/SearchUtils.cs
+++ b/Logic/MCTS/SearchUtils.cs
@@ -32,12 +32,14 @@ public static unsafe class SearchUtils
 
     public static float GetTemperatureAdjustment(int depth, float q)
     {
-        var value = (q - Math.Min(q, TemperatureQInc)) / (1.0f - TemperatureQInc);
+        var winningAdj = TemperatureScale * ((q - Math.Min(q, TemperatureQInc)) / (1.0f - TemperatureQInc));
+
+        var depthAdj = (2.15f / MathF.Pow(depth, 1.60f)) - 0.15f;
 
         //  sin(x * pi / 2) / 8
-        var dCoef = ((2 - (depth % 4)) * (depth % 2)) / 8.0f;
+        var sinAdj = ((2 - (depth % 4)) * (depth % 2)) / 25.0f;
 
-        return 1.0f + value * TemperatureScale + dCoef;
+        return 1.0f + winningAdj + depthAdj + sinAdj;
     }
 
     public static float PolicyForMove(Position pos, Move move)


### PR DESCRIPTION
```
Elo   | 54.16 +- 15.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 970 W: 366 L: 216 D: 388
Penta | [13, 86, 179, 152, 55]
```
https://somelizard.pythonanywhere.com/test/2649/