### PR TITLE
Fix TT memory usage

### DIFF
--- a/Logic/MCTS/Tree.cs
+++ b/Logic/MCTS/Tree.cs
@@ -35,20 +35,26 @@ public unsafe class Tree
         NodesLength = 0;
         Filled = 0;
 
-        TT = new TranspositionTable(mb / 4);
+        TT = new();
 
         Resize(mb);
     }
 
-    public void Resize(int mb)
+    public void Resize(int numMB)
     {
         if (Nodes != default)
             NativeMemory.AlignedFree(Nodes);
 
-        NodesLength = (ulong)mb * 0x100000UL / (ulong)sizeof(Node);
-        Nodes = AlignedAllocZeroed<Node>((nuint)NodesLength);
+        ulong mb = (ulong)numMB * 1024 * 1024;
 
-        TT.Resize(mb / 4);
+        ulong div = (ulong)sizeof(TTEntry) + ((ulong)sizeof(Node) * 4);
+        ulong entriesToAlloc = mb / div;
+        ulong nodesToAlloc = entriesToAlloc * 4;
+
+        NodesLength = nodesToAlloc;
+        Nodes = AlignedAllocZeroedHuge<Node>((nuint)NodesLength);
+
+        TT.Resize(entriesToAlloc);
     }
 
     public void Clear()

--- a/Logic/Transposition/TranspositionTable.cs
+++ b/Logic/Transposition/TranspositionTable.cs
@@ -8,17 +8,14 @@ public unsafe class TranspositionTable
     private TTEntry* Entries;
     public ulong EntryCount { get; private set; }
 
-    public TranspositionTable(int mb)
-    {
-        Resize(mb);
-    }
+    public TranspositionTable() { }
 
-    public unsafe void Resize(int mb)
+    public unsafe void Resize(ulong numEntries)
     {
         if (Entries != null)
             NativeMemory.AlignedFree(Entries);
 
-        EntryCount = (ulong)mb * 0x100000UL / (ulong)sizeof(TTEntry);
+        EntryCount = numEntries;
         nuint allocSize = ((nuint)sizeof(TTEntry) * (nuint)EntryCount);
 
         //  On Linux, also inform the OS that we want it to use large pages

--- a/Logic/Util/Interop.cs
+++ b/Logic/Util/Interop.cs
@@ -166,6 +166,16 @@ namespace AwesomeOpossum.Logic.Util
             return (T*)block;
         }
 
+        public static unsafe T* AlignedAllocZeroedHuge<T>(nuint items, nuint alignment = (1024 * 1024))
+        {
+            nuint bytes = ((nuint)sizeof(T) * (nuint)items);
+            void* block = NativeMemory.AlignedAlloc(bytes, alignment);
+            NativeMemory.Clear(block, bytes);
+            AdviseHugePage(block, bytes);
+
+            return (T*)block;
+        }
+
 
         public static unsafe void AdviseHugePage(void* addr, nuint length)
         {


### PR DESCRIPTION

```
Elo   | -0.32 +- 6.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 1.65 (-2.25, 2.89) [-10.00, 0.00]
Games | N: 4404 W: 1302 L: 1306 D: 1796
Penta | [121, 490, 971, 512, 108]
```
https://somelizard.pythonanywhere.com/test/2661/