### PR TITLE
Tune at 20.0+0.2

### DIFF
--- a/src/AwesomeOpossum/Logic/MCTS/SearchUtils.cs
+++ b/src/AwesomeOpossum/Logic/MCTS/SearchUtils.cs
@@ -24,7 +24,7 @@ public static unsafe class SearchUtils
 
     public static float GetFPU(in Node node)
     {
-        return 1.0f - node.QValue;
+        return FPUBase - node.QValue;
     }
 
     public static float GetExplorationScale(in Node node)

--- a/src/AwesomeOpossum/Logic/Search/SearchOptions.cs
+++ b/src/AwesomeOpossum/Logic/Search/SearchOptions.cs
@@ -13,22 +13,22 @@
         public static bool Minimal = false;
 
 
-        public static float ExplTau = 0.6493f;
-        public static float GiniBase = 0.6700f;
-        public static float GiniScale = 1.5000f;
-        public static float GiniMin = 2.1500f;
-        public static float CPuctVisitScale = 3999.7565f;
-        public static float CPuctBaseRoot = 0.5141f;
-        public static float CPuctBase = 0.2793f;
-        public static float FPUBase = 1.0000f;
-        public static float PSTQInc = 0.7948f;
-        public static float PSTQScale = 0.2565f;
-        public static float PSTNumer = 2.2689f;
-        public static float PSTPow = 1.4886f;
-        public static float PSTOffset = 0.1502f;
-        public static float PSTSinDiv = 25.5294f;
+        public static float ExplTau = 0.659278f;
+        public static float GiniBase = 0.663742f;
+        public static float GiniScale = 1.544302f;
+        public static float GiniMin = 2.136079f;
+        public static float CPuctVisitScale = 4077.954306f;
+        public static float CPuctBaseRoot = 0.520352f;
+        public static float CPuctBase = 0.261141f;
+        public static float FPUBase = 1.019626f;
+        public static float PSTQInc = 0.801457f;
+        public static float PSTQScale = 0.252099f;
+        public static float PSTNumer = 2.371023f;
+        public static float PSTPow = 1.342446f;
+        public static float PSTOffset = 0.140031f;
+        public static float PSTSinDiv = 26.110095f;
 
-        public static float StabilityBase = 0.9000f;
-        public static float StabilityMul = 0.1440f;
+        public static float StabilityBase = 0.976387f;
+        public static float StabilityMul = 0.143435f;
     }
 }

--- a/src/AwesomeOpossum/Logic/Search/SearchOptions.cs
+++ b/src/AwesomeOpossum/Logic/Search/SearchOptions.cs
@@ -20,11 +20,15 @@
         public static float CPuctVisitScale = 3999.7565f;
         public static float CPuctBaseRoot = 0.5141f;
         public static float CPuctBase = 0.2793f;
+        public static float FPUBase = 1.0000f;
         public static float PSTQInc = 0.7948f;
         public static float PSTQScale = 0.2565f;
         public static float PSTNumer = 2.2689f;
         public static float PSTPow = 1.4886f;
         public static float PSTOffset = 0.1502f;
         public static float PSTSinDiv = 25.5294f;
+
+        public static float StabilityBase = 0.9000f;
+        public static float StabilityMul = 0.1440f;
     }
 }

--- a/src/AwesomeOpossum/Logic/Threads/SearchThread.cs
+++ b/src/AwesomeOpossum/Logic/Threads/SearchThread.cs
@@ -265,6 +265,8 @@ namespace AwesomeOpossum.Logic.Threads
             float bestScore = 0;
             uint bmChanges = 0;
 
+            var softTimeLimit = TimeManager.SoftTimeLimit;
+
             while (!ShouldStop())
             {
                 uint usedDepth = 0;
@@ -327,9 +329,8 @@ namespace AwesomeOpossum.Logic.Threads
 
                     if (PlayoutIteration % 4096 == 0 && TimeManager.HasSoftTime)
                     {
-                        double bmStability = (0.90 + (Math.Log(bmChanges + 1) * 0.144));
-
-                        if (TimeManager.GetSearchTime() >= TimeManager.SoftTimeLimit * bmStability)
+                        var bmStability = (StabilityBase + (float.Log(bmChanges + 1) * StabilityMul));
+                        if (TimeManager.GetSearchTime() >= softTimeLimit * bmStability)
                             SetStop();
 
                         bmChanges = 0;


### PR DESCRIPTION
https://somelizard.pythonanywhere.com/tune/2709/

---

```
Elo   | 28.86 +- 11.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1774 W: 656 L: 509 D: 609
Penta | [35, 165, 378, 236, 73]
```
https://somelizard.pythonanywhere.com/test/2712/

---

```
Elo   | 31.55 +- 11.26 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=64MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1546 W: 560 L: 420 D: 566
Penta | [27, 125, 357, 209, 55]
```
https://somelizard.pythonanywhere.com/test/2711/