### PR TITLE
Factor in best move effort in time management

### DIFF
--- a/src/AwesomeOpossum/Logic/Search/SearchOptions.cs
+++ b/src/AwesomeOpossum/Logic/Search/SearchOptions.cs
@@ -30,5 +30,10 @@
 
         public static float StabilityBase = 0.976387f;
         public static float StabilityMul = 0.143435f;
+
+        public static float EffortOffset = 2.500000f;
+        public static float EffortMul = 0.500000f;
+        public static float EffortBase = 1.000000f;
+
     }
 }

--- a/src/AwesomeOpossum/Logic/Threads/SearchThread.cs
+++ b/src/AwesomeOpossum/Logic/Threads/SearchThread.cs
@@ -334,7 +334,7 @@ namespace AwesomeOpossum.Logic.Threads
                         bmChanges = 0;
 
                         var visits = -(Tree[bestChildPtr].Visits / (double)PlayoutIteration);
-                        var effort = Math.Log((visits + 2.5) * 0.5) + 1;
+                        var effort = Math.Log((visits + EffortOffset) * EffortMul) + EffortBase;
 
                         var limit = softTimeLimit * bmStability * effort;
                         if (TimeManager.GetSearchTime() >= limit)

--- a/src/AwesomeOpossum/Logic/Threads/SearchThread.cs
+++ b/src/AwesomeOpossum/Logic/Threads/SearchThread.cs
@@ -261,6 +261,7 @@ namespace AwesomeOpossum.Logic.Threads
 #endif
             }
 
+            NodePointer bestChildPtr = default;
             Move bestMove = Move.Null, lastBestMove = Move.Null;
             float bestScore = 0;
             uint bmChanges = 0;
@@ -291,7 +292,7 @@ namespace AwesomeOpossum.Logic.Threads
 #if !DATAGEN
                 if (PlayoutIteration % 128 == 0)
                 {
-                    (_, bestMove, bestScore) = Tree.GetBestAction(Tree.RootNodePointer);
+                    (bestChildPtr, bestMove, bestScore) = Tree.GetBestAction(Tree.RootNodePointer);
                     if (bestMove != lastBestMove)
                     {
                         bmChanges++;
@@ -330,10 +331,14 @@ namespace AwesomeOpossum.Logic.Threads
                     if (PlayoutIteration % 4096 == 0 && TimeManager.HasSoftTime)
                     {
                         var bmStability = (StabilityBase + (float.Log(bmChanges + 1) * StabilityMul));
-                        if (TimeManager.GetSearchTime() >= softTimeLimit * bmStability)
-                            SetStop();
-
                         bmChanges = 0;
+
+                        var visits = -(Tree[bestChildPtr].Visits / (double)PlayoutIteration);
+                        var effort = Math.Log((visits + 2.5) * 0.5) + 1;
+
+                        var limit = softTimeLimit * bmStability * effort;
+                        if (TimeManager.GetSearchTime() >= limit)
+                            SetStop();
                     }
 
                     if (PlayoutIteration % 1024 == 0 && TimeManager.CheckHardTime())


### PR DESCRIPTION
```
Elo   | 11.45 +- 6.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4128 W: 1391 L: 1255 D: 1482
Penta | [75, 328, 1141, 426, 94]
```
https://somelizard.pythonanywhere.com/test/2715/

---

```
Elo   | 14.15 +- 11.04 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.09 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1130 W: 356 L: 310 D: 464
Penta | [13, 87, 325, 121, 19]
```
https://somelizard.pythonanywhere.com/test/2716/